### PR TITLE
Allow use with rake 0.9.x

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -13,7 +13,7 @@ Hoe.spec 'rake-remote_task' do
 
   self.rubyforge_name = 'hitsquad'
 
-  extra_deps << ['rake',  '~> 0.8.0']
+  extra_deps << ['rake',  '>= 0.8.0', '< 0.10.0']
   extra_deps << ['open4', '~> 0.9.0']
 
   extra_dev_deps << ['minitest', '~> 1.7.0']


### PR DESCRIPTION
This expands the version dependency on rake from ~> 0.8.0 (i.e. >= 0.8.0, < 0.9.0) to >= 0.8.0, < 0.10.0, the minimal expansion necessary to allow rake-remote_task to be used with the newly released rake 0.9.x.
