### PR TITLE
Fix #9 concurrent modification in test with real threads

### DIFF
--- a/lib/rake/test_case.rb
+++ b/lib/rake/test_case.rb
@@ -65,6 +65,7 @@ class Rake::TestCase < MiniTest::Unit::TestCase
     Rake.application.clear
     @task_count = Rake.application.tasks.size
     @rake.set :domain, "example.com"
+    @lock = Mutex.new
   end
 
   def util_set_hosts

--- a/test/test_rake_remote_task.rb
+++ b/test/test_rake_remote_task.rb
@@ -24,7 +24,11 @@ class TestRakeRemoteTask < Rake::TestCase
     set :can_set_nil, nil
     set :lies_are, false
     x = 5
-    task = @rake.remote_task(:some_task) { x += some_variable }
+    task = @rake.remote_task(:some_task) do
+      @lock.synchronize do
+        x += some_variable
+      end
+    end
     task.execute nil
     assert_equal 1, task.some_variable
     assert_equal 7, x


### PR DESCRIPTION
On jruby and multi-core host:

```
% jruby -v
jruby 1.6.5 (ruby-1.8.7-p330) (2011-10-25 9dcd388) (Java HotSpot(TM) Server VM 1.7.0_02) [linux-i386-java]
```

I'm seeing this test failure consistently:

```
Run options: --seed 46401

# Running tests:

.......F...........

Finished tests in 0.200000s, 95.0000 tests/s, 275.0000 assertions/s.

  1) Failure:
test_execute(TestRakeRemoteTask) [./test/test_rake_remote_task.rb:30]:
Expected: 7
  Actual: 6

19 tests, 55 assertions, 1 failures, 0 errors, 0 skips
```

What am I doing with jruby you ask? I am trying to make rake-remote_task work on it.

However, other real-threaded rubies might have the same problem.
