### PR TITLE
Add compatibility support for JRuby

### DIFF
--- a/Manifest.txt
+++ b/Manifest.txt
@@ -5,4 +5,6 @@ README.txt
 Rakefile
 lib/rake/remote_task.rb
 lib/rake/test_case.rb
+lib/rake/remote_task/open3.rb
+lib/rake/remote_task/open4.rb
 test/test_rake_remote_task.rb

--- a/README.txt
+++ b/README.txt
@@ -45,7 +45,7 @@ To set ssh flags for the login and port:
 == REQUIREMENTS:
 
 * rake
-* open4 gem
+* open4 gem (on MRI ruby; not needed for jruby)
 
 == INSTALL:
 

--- a/Rakefile
+++ b/Rakefile
@@ -14,9 +14,13 @@ Hoe.spec 'rake-remote_task' do
   self.rubyforge_name = 'hitsquad'
 
   dependency 'rake',     '~> 0.8'
-  dependency 'open4',    '~> 1.0'
+  dependency 'open4',    '~> 1.0' unless RUBY_PLATFORM =~ /java/
 
   multiruby_skip << "rubinius"
+
+  if RUBY_PLATFORM =~ /java/
+    spec_extras[ :platform ] = Gem::Platform.new( "java" )
+  end
 end
 
 # vim: syntax=ruby

--- a/lib/rake/remote_task.rb
+++ b/lib/rake/remote_task.rb
@@ -1,5 +1,4 @@
 require 'rubygems'
-require 'open4'
 require 'rake'
 
 $TESTING ||= false
@@ -47,9 +46,15 @@ class Rake::RemoteTask < Rake::Task
 
   VERSION = "2.0.5"
 
-  @@current_roles = []
+  if RUBY_PLATFORM =~ /java/
+    require 'rake/remote_task/open3'
+    include Rake::RemoteOpen3
+  else
+    require 'rake/remote_task/open4'
+    include Rake::RemoteOpen4
+  end
 
-  include Open4
+  @@current_roles = []
 
   ##
   # Options for execution of this task.
@@ -164,70 +169,6 @@ class Rake::RemoteTask < Rake::Task
     success = system(*cmd)
 
     raise Rake::CommandFailedError.new($?), "execution failed: #{cmdstr}" unless success
-  end
-
-  ##
-  # Use ssh to execute +command+ on target_host. If +command+ uses sudo, the
-  # sudo password will be prompted for then saved for subsequent sudo commands.
-
-  def run command
-    command = "cd #{target_dir} && #{command}" if target_dir
-    cmd     = [ssh_cmd, ssh_flags, target_host, command].flatten
-    result  = []
-
-    trace = [ssh_cmd, ssh_flags, target_host, "'#{command}'"].flatten.join(' ')
-    warn trace if $TRACE
-
-    pid, inn, out, err = popen4(*cmd)
-
-    inn.sync   = true
-    streams    = [out, err]
-    out_stream = {
-      out => $stdout,
-      err => $stderr,
-    }
-
-    # Handle process termination ourselves
-    status = nil
-    Thread.start do
-      status = Process.waitpid2(pid).last
-    end
-
-    until streams.empty? do
-      # don't busy loop
-      selected, = select streams, nil, nil, 0.1
-
-      next if selected.nil? or selected.empty?
-
-      selected.each do |stream|
-        if stream.eof? then
-          streams.delete stream if status # we've quit, so no more writing
-          next
-        end
-
-        data = stream.readpartial(1024)
-        out_stream[stream].write data
-
-        if stream == err and data =~ sudo_prompt then
-          inn.puts sudo_password
-          data << "\n"
-          $stderr.write "\n"
-        end
-
-        result << data
-      end
-    end
-
-    unless status.success? then
-      raise(Rake::CommandFailedError.new(status),
-            "execution failed with status #{status.exitstatus}: #{cmd.join ' '}")
-    end
-
-    result.join
-  ensure
-    inn.close rescue nil
-    out.close rescue nil
-    err.close rescue nil
   end
 
   ##

--- a/lib/rake/remote_task.rb
+++ b/lib/rake/remote_task.rb
@@ -1,5 +1,6 @@
 require 'rubygems'
 require 'rake'
+require 'thread'
 
 $TESTING ||= false
 $TRACE = Rake.application.options.trace

--- a/lib/rake/remote_task/open3.rb
+++ b/lib/rake/remote_task/open3.rb
@@ -1,11 +1,13 @@
 require 'open3'
 
+##
 # Implementation of +run+ using stdlib Open3. Currently this is only
 # viable on JRuby where the exit status may be obtained. By comparison
 # open4 requires a fork which isn't available on JRuby.
 module Rake::RemoteOpen3
   include Open3
 
+  ##
   # Use ssh to execute +command+ on target_host. If +command+ uses
   # sudo, the sudo password will be prompted for then saved for
   # subsequent sudo commands.
@@ -78,6 +80,7 @@ module Rake::RemoteOpen3
 
   private
 
+  ##
   # Test hook for injecting status (can't set $?)
   def test_status
     nil

--- a/lib/rake/remote_task/open3.rb
+++ b/lib/rake/remote_task/open3.rb
@@ -1,0 +1,68 @@
+require 'open3'
+
+module Rake::RemoteOpen3
+  include Open3
+
+  # Use ssh to execute +command+ on target_host. If +command+ uses sudo, the
+  # sudo password will be prompted for then saved for subsequent sudo commands.
+  def run command
+    command = "cd #{target_dir} && #{command}" if target_dir
+    cmd     = [ssh_cmd, ssh_flags, target_host, command].flatten
+    result  = []
+
+    trace = [ssh_cmd, ssh_flags, target_host, "'#{command}'"].flatten.join(' ')
+    warn trace if $TRACE
+
+    popen3(*cmd) do |inn,out,err|
+
+      inn.sync   = true
+      streams    = [out, err]
+      out_stream = {
+        out => $stdout,
+        err => $stderr,
+      }
+
+      until streams.empty? do
+        # don't busy loop
+        selected, = select(streams, nil, nil, 0.1)
+
+        next if selected.nil? or selected.empty?
+
+        selected.each do |stream|
+          if stream.eof? then
+            streams.delete stream
+            next
+          end
+
+          data = stream.readpartial(1024)
+          out_stream[stream].write data
+
+          if stream == err and data =~ sudo_prompt then
+            inn.puts sudo_password
+            data << "\n"
+            $stderr.write "\n"
+          end
+
+          result << data
+        end
+      end
+      inn.close rescue nil
+    end
+    status = test_status || $?
+
+    unless status.exitstatus == 0 then
+      raise(Rake::CommandFailedError.new(status),
+            "execution failed with status #{status.exitstatus}: #{cmd.join ' '}")
+    end
+
+    result.join
+  end
+
+  private
+
+  # Test hook for injecting status (can't set $?)
+  def test_status
+    nil
+  end
+
+end

--- a/lib/rake/remote_task/open4.rb
+++ b/lib/rake/remote_task/open4.rb
@@ -1,0 +1,69 @@
+require 'open4'
+
+module Rake::RemoteOpen4
+  include Open4
+
+  ##
+  # Use ssh to execute +command+ on target_host. If +command+ uses sudo, the
+  # sudo password will be prompted for then saved for subsequent sudo commands.
+  def run command
+    command = "cd #{target_dir} && #{command}" if target_dir
+    cmd     = [ssh_cmd, ssh_flags, target_host, command].flatten
+    result  = []
+
+    trace = [ssh_cmd, ssh_flags, target_host, "'#{command}'"].flatten.join(' ')
+    warn trace if $TRACE
+
+    pid, inn, out, err = popen4(*cmd)
+
+    inn.sync   = true
+    streams    = [out, err]
+    out_stream = {
+      out => $stdout,
+      err => $stderr,
+    }
+
+    # Handle process termination ourselves
+    status = nil
+    Thread.start do
+      status = Process.waitpid2(pid).last
+    end
+
+    until streams.empty? do
+      # don't busy loop
+      selected, = select streams, nil, nil, 0.1
+
+      next if selected.nil? or selected.empty?
+
+      selected.each do |stream|
+        if stream.eof? then
+          streams.delete stream if status # we've quit, so no more writing
+          next
+        end
+
+        data = stream.readpartial(1024)
+        out_stream[stream].write data
+
+        if stream == err and data =~ sudo_prompt then
+          inn.puts sudo_password
+          data << "\n"
+          $stderr.write "\n"
+        end
+
+        result << data
+      end
+    end
+
+    unless status.success? then
+      raise(Rake::CommandFailedError.new(status),
+            "execution failed with status #{status.exitstatus}: #{cmd.join ' '}")
+    end
+
+    result.join
+  ensure
+    inn.close rescue nil
+    out.close rescue nil
+    err.close rescue nil
+  end
+
+end

--- a/lib/rake/remote_task/open4.rb
+++ b/lib/rake/remote_task/open4.rb
@@ -1,11 +1,16 @@
 require 'open4'
 
+##
+# Implementation of +run+ using Open4. This uses fork underneath and
+# therefore only works where fork works (jruby is a notable exception,
+# see RemoteOpen3)
 module Rake::RemoteOpen4
   include Open4
 
   ##
-  # Use ssh to execute +command+ on target_host. If +command+ uses sudo, the
-  # sudo password will be prompted for then saved for subsequent sudo commands.
+  # Use ssh to execute +command+ on target_host. If +command+ uses
+  # sudo, the sudo password will be prompted for then saved for
+  # subsequent sudo commands.
   def run command
     command = "cd #{target_dir} && #{command}" if target_dir
     cmd     = [ssh_cmd, ssh_flags, target_host, command].flatten

--- a/lib/rake/test_case.rb
+++ b/lib/rake/test_case.rb
@@ -51,9 +51,27 @@ class Rake::RemoteTask
     return 42, @input, out, err
   end
 
+  def popen3( *command )
+    @commands << command
+
+    @input = StringIO.new
+    out = StringIO.new @output.shift.to_s
+    err = StringIO.new @error.shift.to_s
+
+    status = self.action ? self.action[command.join(' ')] : 0
+    Process.expected Status.new(status)
+
+    yield( @input, out, err )
+  end
+
   def select reads, writes, errs, timeout
     [reads, writes, errs]
   end
+
+  def test_status
+    Process.waitpid2(0).first
+  end
+
 end
 
 class Rake::TestCase < MiniTest::Unit::TestCase


### PR DESCRIPTION
As you may be aware, open4 doesn't work on jruby, because it uses fork which isn't JVM friendly.

I am able to get jruby 1.6.x working by adding an alternative implementation of `RemoteTask.run` which uses jruby's popen3.   This is done by way of selective mixin of new Open3 or Open4 modules.  Details of how this works in jruby is commented in open3.rb. 
