### PR TITLE
Trust remote umask by default, fix #16

### DIFF
--- a/lib/rake/remote_task.rb
+++ b/lib/rake/remote_task.rb
@@ -455,7 +455,7 @@ class Rake::RemoteTask < Rake::Task
                :sudo_cmd,           "sudo",
                :sudo_flags,         ['-p Password:'],
                :sudo_prompt,        /^Password:/,
-               :umask,              '02',
+               :umask,              nil,
                :mkdirs,             [],
                :shared_paths,       {},
                :perm_owner,         nil,


### PR DESCRIPTION
Just like in the case of Vlad, I think forcing a loose umask by default is a big security issue... (as stated in #16)

Mathieu.
