### PR TITLE
Feature/allows a set of commands to be always run remotely

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,0 +1,1 @@
+gemspec

--- a/lib/rake-remote_task/version.rb
+++ b/lib/rake-remote_task/version.rb
@@ -1,5 +1,5 @@
 module Rake
   module RemoteTaskGem
-    VERSION = "2.0.7"
+    VERSION = "2.1.0.alpha"
   end
 end

--- a/lib/rake-remote_task/version.rb
+++ b/lib/rake-remote_task/version.rb
@@ -1,0 +1,5 @@
+module Rake
+  module RemoteTaskGem
+    VERSION = "2.0.7"
+  end
+end

--- a/lib/rake/remote_task.rb
+++ b/lib/rake/remote_task.rb
@@ -467,7 +467,7 @@ class Rake::RemoteTask < Rake::Task
                :shared_paths,       {},
                :perm_owner,         nil,
                :perm_group,         nil,
-               :command_prefix,     nil)
+               :command_prefix,     [])
 
     set(:current_release)    { File.join(releases_path, releases[-1]) }
     set(:latest_release)     {

--- a/lib/rake/remote_task.rb
+++ b/lib/rake/remote_task.rb
@@ -173,7 +173,12 @@ class Rake::RemoteTask < Rake::Task
   # sudo password will be prompted for then saved for subsequent sudo commands.
 
   def run command
-    command = "cd #{target_dir} && #{command}" if target_dir
+    command = [
+               ("cd #{target_dir}"  if target_dir),
+               command_prefix,
+               "#{command}"
+              ].flatten.delete_if { |x| x.nil? or x == "" }.join(" && ")
+
     cmd     = [ssh_cmd, ssh_flags, target_host, command].flatten
     result  = []
 
@@ -461,7 +466,8 @@ class Rake::RemoteTask < Rake::Task
                :mkdirs,             [],
                :shared_paths,       {},
                :perm_owner,         nil,
-               :perm_group,         nil)
+               :perm_group,         nil,
+               :command_prefix,     nil)
 
     set(:current_release)    { File.join(releases_path, releases[-1]) }
     set(:latest_release)     {

--- a/lib/rake/remote_task.rb
+++ b/lib/rake/remote_task.rb
@@ -2,6 +2,8 @@ require 'rubygems'
 require 'open4'
 require 'rake'
 
+require 'rake-remote_task/version'
+
 $TESTING ||= false
 $TRACE = Rake.application.options.trace
 $-w = true if $TRACE # asshat, don't mess with my warn.
@@ -45,7 +47,7 @@ end
 
 class Rake::RemoteTask < Rake::Task
 
-  VERSION = "2.0.6"
+  VERSION = Rake::RemoteTaskGem::VERSION
 
   @@current_roles = []
 

--- a/rake-remote_task.gemspec
+++ b/rake-remote_task.gemspec
@@ -1,0 +1,29 @@
+# -*- encoding: utf-8 -*-
+lib = File.expand_path('../lib', __FILE__)
+$LOAD_PATH.unshift(lib) unless $LOAD_PATH.include?(lib)
+require 'rake-remote_task/version'
+
+Gem::Specification.new do |gem|
+  gem.name = "rake-remote_task"
+  gem.version = Rake::RemoteTaskGem::VERSION
+  gem.authors = ["Ryan Davis", "Eric Hodel", "Wilson Bilkovich"]
+  gem.email = ["ryand-ruby@zenspider.com", "drbrain@segment7.net", "wilson@supremetyrant.com"]
+  gem.description = %q{Vlad the Deployer's sexy brainchild is rake-remote_task, extending
+Rake with remote task goodness.}
+  gem.summary = %q{Vlad the Deployer's sexy brainchild is rake-remote_task, extending Rake with remote task goodness.}
+  gem.homepage = %q{http://rubyhitsquad.com/}
+
+  gem.files         = `git ls-files`.split($/)
+  gem.executables   = gem.files.grep(%r{^bin/}).map{ |f| File.basename(f) }
+  gem.test_files    = gem.files.grep(%r{^(test|spec|features)/})
+  gem.require_paths = ["lib"]
+
+  gem.rdoc_options = ["--main", "README.txt"]
+  gem.extra_rdoc_files = ["History.txt", "Manifest.txt", "README.txt"]
+
+   gem.add_runtime_dependency("rake", ["~> 0.8"])
+   gem.add_runtime_dependency("open4", ["~> 1.0"])
+
+   gem.add_development_dependency("minitest", ["~> 1.7.0"])
+   gem.add_development_dependency("hoe", [">= 2.9.1"])
+end


### PR DESCRIPTION
The point of this feature is to allow, for example, RVM initialization or any other kind of environment initialization.
For example: check https://github.com/lemoinem/vlad-extras/commit/8f620fdabbc8310c37499afd0b521692dfaaaa81

PS: Several commits were pulled in with the PR.

Important commits are 26599dd and 920cc34. Just tell me if you want them cleaned up and rebased onto seattlerb/master.