### PR TITLE
:domain_prefix option added for Vagrant integration

### DIFF
--- a/lib/rake/remote_task.rb
+++ b/lib/rake/remote_task.rb
@@ -181,6 +181,7 @@ class Rake::RemoteTask < Rake::Task
     commands << "#{command}"
 
     command = commands.join(" && ")
+    command = "#{domain_prefix} #{command}" if domain_prefix
 
     cmd     = [ssh_cmd, ssh_flags, target_host, command].flatten
     result  = []
@@ -513,7 +514,8 @@ class Rake::RemoteTask < Rake::Task
                :mkdirs,             [],
                :shared_paths,       {},
                :perm_owner,         nil,
-               :perm_group,         nil)
+               :perm_group,         nil,
+               :domain_prefix,      nil)
 
     append :command_prefix, []
 

--- a/test/test_rake_remote_task.rb
+++ b/test/test_rake_remote_task.rb
@@ -205,6 +205,19 @@ class TestRakeRemoteTask < Rake::TestCase
     assert_equal [["ssh", "app.example.com", "cd /www/dir1 && ls"]], commands
   end
 
+  def test_run_domain_prefix
+    util_setup_task 
+    @task.target_host = "app.example.com"
+    @rake.set :domain_prefix, "-c"
+   
+    @task.run("ls")
+  
+    commands = @task.commands
+  
+    assert_equal [["ssh", "app.example.com", "-c ls"]], commands
+    @rake.default_env["domain_prefix"] = nil # a teardown hack; there's probably a better approach.
+  end
+
   def test_run_failing_command
     util_set_hosts
     util_setup_task


### PR DESCRIPTION
The basis for this change is discussed in greater detail in Vlad Issued #37.

This change adds a :domain_prefix option which will allow a Vagrant user to execute commands through RRT by way of Vlad. To my knowledge the only way to execute a command to a Vagrant VM is the following:

```
vagrant ssh <vm> -c '<command>'
```

That "-c" part is what looks to be a non-starter with RRT in it's current state. With this change, a Vlad user wishing to deploy to Vagrant machines could set their configuration this way:

```
set :domain, "vagrant_vm"
set :ssh_cmd, %w[vagrant ssh]
set :domain_prefix, "-c"
```

I kept the :domain_prefix as generic as possible should there be any other use cases out there. I initially tried wiring :domain_prefix up as an array so that multiple commands could be passed in. But as of now there are no additional commands a Vagrant user can pass before executing a remote command.

You'll notice that in the last line of my test case I hacked a teardown. A way to reset :domain_prefix to nil without making ancillary changes to either the test file or the production code was not immediately obvious to me. I'm open to a better way to do this.
