### PR TITLE
Create private methods from Rake::RemoteTask#set

### DIFF
--- a/lib/rake/remote_task.rb
+++ b/lib/rake/remote_task.rb
@@ -446,7 +446,7 @@ class Rake::RemoteTask < Rake::Task
     Rake::RemoteTask.default_env[name] = Rake::RemoteTask.env[name] =
       default_block || value
 
-    if Object.public_instance_methods.include? name.to_sym then
+    if Object.private_instance_methods.include? name.to_sym then
       Object.send :alias_method, :"old_#{name}", name
     end
 

--- a/lib/rake/remote_task.rb
+++ b/lib/rake/remote_task.rb
@@ -453,6 +453,8 @@ class Rake::RemoteTask < Rake::Task
     Object.send :define_method, name do
       Rake::RemoteTask.fetch name
     end
+
+    Object.send :private, name
   end
 
   ##

--- a/test/test_rake_remote_task.rb
+++ b/test/test_rake_remote_task.rb
@@ -35,19 +35,19 @@ class TestRakeRemoteTask < Rake::TestCase
       end
     end
     task.execute nil
-    assert_equal 1, task.some_variable
+    assert_equal 1, task.send(:some_variable)
     assert_equal 7, x
-    assert task.can_set_nil.nil?
-    assert_equal false, task.lies_are
+    assert task.send(:can_set_nil).nil?
+    assert_equal false, task.send(:lies_are)
   end
 
   def test_set_false
     set :can_set_nil, nil
     set :lies_are, false
 
-    assert_equal nil,   task.can_set_nil
+    assert_equal nil,   task.send(:can_set_nil)
 
-    assert_equal false, task.lies_are
+    assert_equal false, task.send(:lies_are)
     assert_equal false, Rake::RemoteTask.fetch(:lies_are)
   end
 
@@ -84,7 +84,7 @@ class TestRakeRemoteTask < Rake::TestCase
     x = 5
     task = @rake.remote_task(:some_task, :roles => :db) { x += some_variable }
     task.execute nil
-    assert_equal 1, task.some_variable
+    assert_equal 1, task.send(:some_variable)
     assert_equal 6, x
   end
 

--- a/test/test_rake_remote_task.rb
+++ b/test/test_rake_remote_task.rb
@@ -3,7 +3,7 @@ require 'rake/test_case'
 class TestRakeRemoteTask < Rake::TestCase
   def teardown
     Object.send :remove_method, :old_domain if
-      Object.public_instance_methods.include? :old_domain
+      Object.private_instance_methods.include? :old_domain
   end
 
   def test_enhance


### PR DESCRIPTION
Rake::RemoteTask creates methods on Object because that is the only
feasible way to extend rake.  This means there may be collisions with
method names used by other projects.  I encountered a collision between
rake-remote_task and pry over the command_prefix method.

By making the methods private the chances of collision are reduced but
compatibility in use is maintained.  Rake tasks are created at top-level
so they can call private methods on Object just fine (like Object#gsub
for ruby -n).

There is an incompatibility in tests, though.  You must use #send to see
if your set-created methods are set properly.  I also have a pull
request to vlad which allows it to work with this pull request to
rake-remote_task.