### PR TITLE
Fix append to not double assign

### DIFF
--- a/lib/rake/remote_task.rb
+++ b/lib/rake/remote_task.rb
@@ -481,7 +481,6 @@ class Rake::RemoteTask < Rake::Task
 
     v = default_block || value
     if v then
-      Rake::RemoteTask.default_env[name] << v
       Rake::RemoteTask.env[name] << v
     end
   end

--- a/test/test_rake_remote_task.rb
+++ b/test/test_rake_remote_task.rb
@@ -259,4 +259,9 @@ class TestRakeRemoteTask < Rake::TestCase
     assert_equal ["ssh", "app.example.com", "sudo -p Password: ls"],
                  commands.first, 'app'
   end
+
+  def test_append
+    append :some_array, 1
+    assert_equal [1], some_array
+  end
 end


### PR DESCRIPTION
default_env[name] and env[name] are the same object, so we only need to
push once.

I don't quite fully follow why default_env is needed, nor how no one
has complained about this.
Should append be removed in favor of:

  set :my_array, [1]
  my_array << 2 # look, append!