### PR TITLE
Extend range of compatible Rake versions to include 11.x

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -11,7 +11,7 @@ Hoe.spec 'rake-remote_task' do
   developer 'Eric Hodel',       'drbrain@segment7.net'
   developer 'Wilson Bilkovich', 'wilson@supremetyrant.com'
 
-  dependency 'rake',    ['>= 0.8', '< 11.0']
+  dependency 'rake',    ['>= 0.8', '< 12.0']
   dependency 'open4',    '~> 1.0'
 
   multiruby_skip << "rubinius"


### PR DESCRIPTION
Hi! I noticed `rake-remote_task` is holding back the rake version for one of my Rails apps, so I tried bumping the compatible version range, and all tests pass with rake 11.2.2.