### PR TITLE
Avoid Fixnum deprecation warning for Ruby 2.4.0 on

### DIFF
--- a/lib/rake/remote_task.rb
+++ b/lib/rake/remote_task.rb
@@ -389,7 +389,7 @@ class Rake::RemoteTask < Rake::Task
 
   def self.safe_dup v # :nodoc:
     case v
-    when Symbol, Fixnum, nil, true, false, 42 then # ummmm... yeah. bite me.
+    when Symbol, Integer, nil, true, false, 42 then # ummmm... yeah. bite me.
       v
     else
       v.dup


### PR DESCRIPTION
I humbly submit a minor change to squish the Fixnum deprecation warning with Ruby 2.4.  Thank you for the useful tool.