### PR TITLE
Extend range of compatible Rake versions to include 12.x

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -11,7 +11,7 @@ Hoe.spec 'rake-remote_task' do
   developer 'Eric Hodel',       'drbrain@segment7.net'
   developer 'Wilson Bilkovich', 'wilson@supremetyrant.com'
 
-  dependency 'rake',    ['>= 0.8', '< 12.0']
+  dependency 'rake',    ['>= 0.8', '< 13.0']
   dependency 'open4',    '~> 1.0'
 
   multiruby_skip << "rubinius"


### PR DESCRIPTION
Hello! I want to use rake 12.0.0. So I tried bumping the compatible version range, and all tests pass with rake 12.0.0.