### PR TITLE
Extend range of compatible Rake versions to include 13.x

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -11,7 +11,7 @@ Hoe.spec 'rake-remote_task' do
   developer 'Eric Hodel',       'drbrain@segment7.net'
   developer 'Wilson Bilkovich', 'wilson@supremetyrant.com'
 
-  dependency 'rake',    ['>= 0.8', '< 13.0']
+  dependency 'rake',    ['>= 0.8', '< 14.0']
   dependency 'open4',    '~> 1.0'
 
   multiruby_skip << "rubinius"


### PR DESCRIPTION
I want to use rake 13.x. So I bumped the compatible version, and all tests pass with rake 13.0.1.

Thank you for this gem!